### PR TITLE
Remove unnecessary loss parameter from get_lr() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ let mut scheduler = CosineAnnealingWarmRestarts::new(
     eta_max, eta_min, t_0, t_mult, init_step
 );
 for epoch in 0 .. 100 {
+    // Get the learning rate for this epoch.
+    let lr = scheduler.get_lr();
     // Calculate loss tensor.
     let loss = (y - labels).sqr().mean_all();
     let loss_scalar = loss.to_f64();
-    // Train a model with a larning rate `lr`.
-    let lr = scheduler.get_lr(loss_scalar);
+    // Train a model with the learning rate `lr`.
     let optimizer = Optimizer::new(lr);
     optimizer.backward_step(&loss);
     // Then update the scheduler for the next iteration.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,8 +7,8 @@
 
 - All schedulers implement the `Scheduler` trait
 - Each scheduler maintains internal state (step counter, current lr)
-- Most schedulers ignore the `loss` parameter (only `ReduceLROnPlateau` uses it)
-- `get_lr()` is idempotent until `step()` is called
+- `get_lr()` returns the current learning rate and is idempotent until `step()` is called
+- `step()` accepts a `loss` parameter for schedulers like `ReduceLROnPlateau` that adjust based on metrics
 - All schedulers support `init_step` for training resumption
 
 ## Core Interface
@@ -16,7 +16,7 @@
 ```rust
 pub trait Scheduler {
     fn step(&mut self, loss: f64);
-    fn get_lr(&self, loss: f64) -> f64;
+    fn get_lr(&self) -> f64;
 }
 ```
 

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::constant::ConstantLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = ConstantLR::new(1.0, 2.0, 2, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [2.0, 2.0, 1.0, 1.0, 1.0]);
@@ -26,10 +25,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 1;
 /// let mut scheduler = ConstantLR::new(1.0, 2.0, 2, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [2.0, 1.0, 1.0, 1.0, 1.0]);
@@ -41,12 +39,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::constant::ConstantLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = ConstantLR::new(1.0, 2.0, 2, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct ConstantLR {
@@ -84,7 +81,7 @@ impl Scheduler for ConstantLR {
         }
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -103,7 +100,7 @@ mod tests {
         let init_step = 0;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in 0..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             if i < total_iters {
                 let expected = factor * base_lr;
                 assert_eq!(lr, expected, "Step {}", i);
@@ -125,7 +122,7 @@ mod tests {
         let init_step = 0;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in 0..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             if i < total_iters {
                 let expected = factor * base_lr;
                 assert_eq!(lr, expected, "Step {}", i);
@@ -147,7 +144,7 @@ mod tests {
         let init_step = 0;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in 0..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             if i < total_iters {
                 let expected = factor * base_lr;
                 assert_eq!(lr, expected, "Step {}", i);
@@ -169,7 +166,7 @@ mod tests {
         let init_step = 0;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in 0..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             let expected = factor * base_lr;
             assert_eq!(lr, expected, "Step {}", i);
             // Proceed a step with dummy loss.
@@ -186,7 +183,7 @@ mod tests {
         let init_step = 0;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in 0..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             let expected = base_lr;
             assert_eq!(lr, expected, "Step {}", i);
             // Proceed a step with dummy loss.
@@ -203,7 +200,7 @@ mod tests {
         let init_step = 1;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in init_step..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             if i < total_iters {
                 let expected = factor * base_lr;
                 assert_eq!(lr, expected, "Step {}", i);
@@ -225,7 +222,7 @@ mod tests {
         let init_step = 3;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in init_step..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             let expected = base_lr;
             assert_eq!(lr, expected, "Step {}", i);
             // Proceed a step with dummy loss.
@@ -242,7 +239,7 @@ mod tests {
         let init_step = 2;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in init_step..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             let expected = base_lr;
             assert_eq!(lr, expected, "Step {}", i);
             // Proceed a step with dummy loss.
@@ -259,7 +256,7 @@ mod tests {
         let init_step = 2;
         let mut scheduler = ConstantLR::new(base_lr, factor, total_iters, init_step);
         for i in init_step..total_steps {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             let expected = base_lr;
             assert_eq!(lr, expected, "Step {}", i);
             // Proceed a step with dummy loss.

--- a/src/cosine_annealing.rs
+++ b/src/cosine_annealing.rs
@@ -13,10 +13,9 @@ const PI: f64 = std::f64::consts::PI;
 /// # use lr_schedulers::Scheduler;
 /// # use std::iter::zip;
 /// let mut scheduler = CosineAnnealingLR::new(1.0, 0.0, 2, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// for (target, expected) in zip(learning_rates, [1.0, 0.5, 0.0, 0.5, 1.0]) {
@@ -32,10 +31,9 @@ const PI: f64 = std::f64::consts::PI;
 /// # use std::iter::zip;
 /// let init_step = 1;
 /// let mut scheduler = CosineAnnealingLR::new(1.0, 0.0, 2, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// for (target, expected) in zip(learning_rates, [0.5, 0.0, 0.5, 1.0, 0.5]) {
@@ -49,12 +47,11 @@ const PI: f64 = std::f64::consts::PI;
 /// # use lr_schedulers::cosine_annealing::CosineAnnealingLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = CosineAnnealingLR::new(1.0, 0.0, 2, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct CosineAnnealingLR {
@@ -96,7 +93,7 @@ impl Scheduler for CosineAnnealingLR {
         self.lr = (self.eta_0 - self.eta_1).mul_add(periodic_factor, self.eta_1);
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -122,7 +119,7 @@ mod tests {
         let mut scheduler = CosineAnnealingLR::new(eta_0, eta_1, t_max, init_step);
         let expected_lrs = [1.0, 0.5, 0.0, 0.5, 1.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",
@@ -144,7 +141,7 @@ mod tests {
         let mut scheduler = CosineAnnealingLR::new(eta_0, eta_1, t_max, init_step);
         let expected_lrs = [0.0, 0.5, 1.0, 0.5, 0.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",
@@ -166,7 +163,7 @@ mod tests {
         let mut scheduler = CosineAnnealingLR::new(eta_0, eta_1, t_max, init_step);
         let expected_lrs = [0.5, 0.0, 0.5, 1.0, 0.5];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",
@@ -189,7 +186,7 @@ mod tests {
         let mut scheduler = CosineAnnealingLR::new(eta_0, eta_1, t_max, init_step);
         let expected_lrs = [1.0, 0.5, 0.0, 0.5].repeat(repeat);
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",

--- a/src/cosine_annealing_warm_restarts.rs
+++ b/src/cosine_annealing_warm_restarts.rs
@@ -13,10 +13,9 @@ const PI: f64 = std::f64::consts::PI;
 /// # use lr_schedulers::Scheduler;
 /// # use std::iter::zip;
 /// let mut scheduler = CosineAnnealingWarmRestarts::new(1.0, 0.0, 2, 1, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// for (target, expected) in zip(learning_rates, [1.0, 0.5, 0.0, 1.0, 0.5]) {
@@ -32,10 +31,9 @@ const PI: f64 = std::f64::consts::PI;
 /// # use std::iter::zip;
 /// let t_mult = 2;
 /// let mut scheduler = CosineAnnealingWarmRestarts::new(1.0, 0.0, 2, t_mult, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 8 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// let expected_lrs = [
@@ -59,12 +57,11 @@ const PI: f64 = std::f64::consts::PI;
 /// # use lr_schedulers::cosine_annealing_warm_restarts::CosineAnnealingWarmRestarts;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = CosineAnnealingWarmRestarts::new(1.0, 0.0, 2, 1, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct CosineAnnealingWarmRestarts {
@@ -124,7 +121,7 @@ impl Scheduler for CosineAnnealingWarmRestarts {
         self.lr = (self.eta_0 - self.eta_1).mul_add(periodic_factor, self.eta_1);
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -150,7 +147,7 @@ mod tests {
         let mut scheduler = CosineAnnealingWarmRestarts::new(eta_0, eta_1, t_0, t_mult, init_step);
         let expected_lrs = [1.0, 0.5, 0.0, 1.0, 0.5, 0.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.01);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",
@@ -182,7 +179,7 @@ mod tests {
             0.0,
         ];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.01);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",
@@ -205,7 +202,7 @@ mod tests {
         let mut scheduler = CosineAnnealingWarmRestarts::new(eta_0, eta_1, t_0, t_mult, init_step);
         let expected_lrs = [0.0, 1.0, 0.5, 0.0, 1.0, 0.5];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.01);
+            let lr = scheduler.get_lr();
             assert!(
                 relative_eq!(lr, *exp_lr),
                 "Step {}: left: {}, right: {}",

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::exponential::ExponentialLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = ExponentialLR::new(2.0, 0.5, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [2.0, 1.0, 0.5, 0.25, 0.125]);
@@ -26,10 +25,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 1;
 /// let mut scheduler = ExponentialLR::new(2.0, 0.5, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 0.5, 0.25, 0.125, 0.0625]);
@@ -41,12 +39,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::exponential::ExponentialLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = ExponentialLR::new(2.0, 0.5, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct ExponentialLR {
@@ -72,7 +69,7 @@ impl Scheduler for ExponentialLR {
         self.lr *= self.gamma;
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -90,7 +87,7 @@ mod tests {
         let mut scheduler = ExponentialLR::new(base_lr, gamma, init_step);
         let expected_lrs = [2.0, 1.0, 0.5, 0.25, 0.125];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Process a step with dummy loss
             scheduler.step(0.0);
@@ -105,7 +102,7 @@ mod tests {
         let mut scheduler = ExponentialLR::new(base_lr, gamma, init_step);
         let expected_lrs = [0.5, 0.25, 0.125, 0.0625];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Process a step with dummy loss
             scheduler.step(0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,5 @@ pub trait Scheduler {
     /// Proceeds the step of scheduler.
     fn step(&mut self, loss: f64);
     /// Returns a learning rate for the current step.
-    ///
-    /// The argument `loss` is for schedulers that require history of loss value such as ReduceLROnPlateau.
-    fn get_lr(&self, loss: f64) -> f64;
+    fn get_lr(&self) -> f64;
 }

--- a/src/linear.rs
+++ b/src/linear.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::linear::LinearLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = LinearLR::new(1.0, 2.0, 0.5, 2, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [2.0, 1.25, 0.5, 0.5, 0.5]);
@@ -26,10 +25,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 1;
 /// let mut scheduler = LinearLR::new(1.0, 2.0, 0.5, 2, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.25, 0.5, 0.5, 0.5, 0.5]);
@@ -41,12 +39,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::linear::LinearLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = LinearLR::new(1.0, 2.0, 0.5, 5, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct LinearLR {
@@ -119,7 +116,7 @@ impl Scheduler for LinearLR {
         }
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -140,7 +137,7 @@ mod tests {
             LinearLR::new(base_lr, start_factor, end_factor, total_iters, init_step);
         let expected_lrs = [2.0, 1.25, 0.5, 0.5, 0.5];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Proceed a step wit dummy loss
             scheduler.step(0.0);
@@ -158,7 +155,7 @@ mod tests {
             LinearLR::new(base_lr, start_factor, end_factor, total_iters, init_step);
         let expected_lrs = [0.5, 1.25, 2.0, 2.0, 2.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Proceed a step wit dummy loss
             scheduler.step(0.0);
@@ -176,7 +173,7 @@ mod tests {
             LinearLR::new(base_lr, start_factor, end_factor, total_iters, init_step);
         let expected_lrs = [1.25, 2.0, 2.0, 2.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Proceed a step wit dummy loss
             scheduler.step(0.0);
@@ -194,7 +191,7 @@ mod tests {
             LinearLR::new(base_lr, start_factor, end_factor, total_iters, init_step);
         let expected_lrs = [2.0, 2.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Proceed a step wit dummy loss
             scheduler.step(0.0);
@@ -212,7 +209,7 @@ mod tests {
             LinearLR::new(base_lr, start_factor, end_factor, total_iters, init_step);
         let expected_lrs = [2.0, 2.0, 2.0];
         for (i, exp_lr) in expected_lrs.iter().enumerate() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_eq!(lr, *exp_lr, "Step {}", i);
             // Proceed a step wit dummy loss
             scheduler.step(0.0);

--- a/src/multiplicative.rs
+++ b/src/multiplicative.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::multiplicative::MultiplicativeLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = MultiplicativeLR::new(1.0, |_| 0.95, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 0.95, 0.9025, 0.857375, 0.81450625]);
@@ -26,10 +25,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let lambda = |epoch| if epoch < 3 { 0.9 } else { 0.95 };
 /// let mut scheduler = MultiplicativeLR::new(1.0, lambda, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 6 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 0.9, 0.81, 0.729, 0.69255, 0.6579225]);
@@ -42,10 +40,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 2;
 /// let mut scheduler = MultiplicativeLR::new(1.0, |_| 0.95, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 3 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [0.9025, 0.857375, 0.81450625]);
@@ -57,12 +54,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::multiplicative::MultiplicativeLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = MultiplicativeLR::new(1.0, |_| 0.95, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct MultiplicativeLR<F>
@@ -107,7 +103,7 @@ where
         self.step += 1;
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -127,7 +123,7 @@ mod tests {
 
         let expected_lrs = [1.0, 0.95, 0.9025, 0.857375, 0.81450625];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-9, max_relative = 1e-9);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -143,7 +139,7 @@ mod tests {
 
         let expected_lrs = [1.0, 0.9, 0.81, 0.729, 0.69255, 0.6579225];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-9, max_relative = 1e-9);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -158,7 +154,7 @@ mod tests {
         let mut scheduler = MultiplicativeLR::new(base_lr, lambda, init_step);
 
         for _ in 0..5 {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, base_lr, epsilon = 1e-9, max_relative = 1e-9);
             scheduler.step(0.0);
         }
@@ -173,7 +169,7 @@ mod tests {
 
         let expected_lrs = [0.1, 0.11, 0.121, 0.1331, 0.14641];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-9, max_relative = 1e-9);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -190,7 +186,7 @@ mod tests {
         // At init_step=2, lr should be 1.0 * 0.95 * 0.95 = 0.9025
         let expected_lrs = [0.9025, 0.857375, 0.81450625];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-9, max_relative = 1e-9);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -217,7 +213,7 @@ mod tests {
         // epoch 4: 0.2025 * 0.9 = 0.18225
         let expected_lrs = [1.0, 0.5, 0.45, 0.405, 0.2025, 0.18225];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-9, max_relative = 1e-9);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -236,12 +232,12 @@ mod tests {
         // epoch 1: 0.8 * 0.8 = 0.64
         // epoch 2: 0.64 * 0.9 = 0.576
         // So at init_step=3, lr = 0.576
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.576, epsilon = 1e-9, max_relative = 1e-9);
 
         // Next steps should use lambda(3) = 0.9, lambda(4) = 0.9, ...
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.5184, epsilon = 1e-9, max_relative = 1e-9);
     }
 }

--- a/src/multistep.rs
+++ b/src/multistep.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::multistep::MultiStepLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = MultiStepLR::new(1.0, vec![3, 7], 0.1, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 10 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.01]);
@@ -25,10 +24,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::multistep::MultiStepLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = MultiStepLR::new(0.5, vec![2, 5, 8], 0.5, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 10 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [0.5, 0.5, 0.25, 0.25, 0.25, 0.125, 0.125, 0.125, 0.0625, 0.0625]);
@@ -41,10 +39,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 4;
 /// let mut scheduler = MultiStepLR::new(1.0, vec![3, 7], 0.1, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [0.1, 0.1, 0.1, 0.01, 0.01]);
@@ -56,12 +53,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::multistep::MultiStepLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = MultiStepLR::new(1.0, vec![3, 7], 0.1, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct MultiStepLR {
@@ -106,7 +102,7 @@ impl Scheduler for MultiStepLR {
         self.lr = self.base_lr * self.gamma.powi(milestones_passed as i32);
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -127,7 +123,7 @@ mod tests {
 
         let expected_lrs = [1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.01];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -145,7 +141,7 @@ mod tests {
             0.5, 0.5, 0.25, 0.25, 0.25, 0.125, 0.125, 0.125, 0.0625, 0.0625,
         ];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -161,13 +157,13 @@ mod tests {
 
         // First 5 steps should have base_lr
         for _ in 0..5 {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, base_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
 
         // After milestone, should be base_lr * gamma
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, base_lr * gamma, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -183,7 +179,7 @@ mod tests {
         // Milestones should be treated as [3, 7, 10]
         let expected_lrs = [1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.01];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -200,7 +196,7 @@ mod tests {
         // At init_step=4, one milestone (3) has been passed
         let expected_lrs = [0.1, 0.1, 0.1, 0.01, 0.01];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -215,11 +211,11 @@ mod tests {
         let mut scheduler = MultiStepLR::new(base_lr, milestones, gamma, init_step);
 
         // At init_step=3, one milestone (3) has been passed
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.1, epsilon = 1e-10, max_relative = 1e-10);
 
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.1, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -233,7 +229,7 @@ mod tests {
 
         let expected_lrs = [0.1, 0.1, 0.2, 0.2, 0.2, 0.4, 0.4];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -249,7 +245,7 @@ mod tests {
 
         // With no milestones, learning rate should remain constant
         for _ in 0..10 {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, base_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -265,12 +261,12 @@ mod tests {
 
         // At init_step=10, both milestones have been passed
         // lr = base_lr * gamma^2 = 1.0 * 0.1^2 = 0.01
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.01, epsilon = 1e-10, max_relative = 1e-10);
 
         // Should remain at this level
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.01, epsilon = 1e-10, max_relative = 1e-10);
     }
 }

--- a/src/onecycle.rs
+++ b/src/onecycle.rs
@@ -14,7 +14,7 @@
 //! let mut scheduler = OneCycleLR::new(0.1, 100, 0.3, AnnealStrategy::Cos, 25.0, 10000.0, false);
 //! let mut learning_rates = Vec::new();
 //! for _ in 0 .. 10 {
-//!     learning_rates.push(scheduler.get_lr(0.0));
+//!     learning_rates.push(scheduler.get_lr());
 //!     scheduler.step(0.0);
 //! }
 //! // Forms 1cycle pattern: low -> high -> very low
@@ -29,7 +29,7 @@
 //! let mut scheduler = OneCycleLR::new(0.1, 50, 0.2, AnnealStrategy::Linear, 10.0, 1000.0, false);
 //! let mut learning_rates = Vec::new();
 //! for _ in 0 .. 8 {
-//!     learning_rates.push(scheduler.get_lr(0.0));
+//!     learning_rates.push(scheduler.get_lr());
 //!     scheduler.step(0.0);
 //! }
 //! // Uses linear interpolation for smoother transitions
@@ -44,7 +44,7 @@
 //! let mut scheduler = OneCycleLR::new(0.1, 60, 0.3, AnnealStrategy::Cos, 25.0, 10000.0, true);
 //! let mut learning_rates = Vec::new();
 //! for _ in 0 .. 12 {
-//!     learning_rates.push(scheduler.get_lr(0.0));
+//!     learning_rates.push(scheduler.get_lr());
 //!     scheduler.step(0.0);
 //! }
 //! // Three phases: warmup -> annealing -> final annealing
@@ -211,7 +211,7 @@ impl Scheduler for OneCycleLR {
         }
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -230,7 +230,7 @@ mod tests {
         // initial_lr = 0.1 / 10.0 = 0.01
         // min_lr = 0.01 / 100.0 = 0.0001
 
-        let lr_start = scheduler.get_lr(0.0);
+        let lr_start = scheduler.get_lr();
         assert_relative_eq!(lr_start, 0.01, epsilon = 1e-10, max_relative = 1e-10);
 
         // Move to warmup steps
@@ -239,7 +239,7 @@ mod tests {
         }
 
         // Should be at or near max_lr
-        let lr_max = scheduler.get_lr(0.0);
+        let lr_max = scheduler.get_lr();
         assert!(lr_max > 0.09); // Should be close to max_lr = 0.1
 
         // Move through annealing
@@ -248,7 +248,7 @@ mod tests {
         }
 
         // Should be at min_lr
-        let lr_final = scheduler.get_lr(0.0);
+        let lr_final = scheduler.get_lr();
         assert_relative_eq!(lr_final, 0.0001, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -261,13 +261,13 @@ mod tests {
         // initial_lr = 0.2 / 20.0 = 0.01
         // min_lr = 0.01 / 1000.0 = 0.00001
 
-        let lr_start = scheduler.get_lr(0.0);
+        let lr_start = scheduler.get_lr();
         assert_relative_eq!(lr_start, 0.01, epsilon = 1e-10, max_relative = 1e-10);
 
         // Test progression through phases
         let mut max_lr_seen = 0.0f64;
         for _ in 0..12 {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             max_lr_seen = max_lr_seen.max(lr);
             scheduler.step(0.0);
         }
@@ -276,7 +276,7 @@ mod tests {
         assert!(max_lr_seen > 0.15);
 
         // Final LR should be min_lr
-        let lr_final = scheduler.get_lr(0.0);
+        let lr_final = scheduler.get_lr();
         assert_relative_eq!(lr_final, 0.00001, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -289,7 +289,7 @@ mod tests {
         let mut phase_lrs = Vec::new();
 
         for step in 0..=10 {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             phase_lrs.push((step, lr));
             if step < 10 {
                 scheduler.step(0.0);
@@ -319,8 +319,8 @@ mod tests {
         let mut lin_lrs = Vec::new();
 
         for _ in 0..8 {
-            cos_lrs.push(cos_scheduler.get_lr(0.0));
-            lin_lrs.push(lin_scheduler.get_lr(0.0));
+            cos_lrs.push(cos_scheduler.get_lr());
+            lin_lrs.push(lin_scheduler.get_lr());
             cos_scheduler.step(0.0);
             lin_scheduler.step(0.0);
         }
@@ -347,11 +347,11 @@ mod tests {
         let mut scheduler =
             OneCycleLR::new(1.0, 2, 0.5, AnnealStrategy::Linear, 10.0, 100.0, false);
 
-        let lr1 = scheduler.get_lr(0.0);
+        let lr1 = scheduler.get_lr();
         scheduler.step(0.0);
-        let lr2 = scheduler.get_lr(0.0);
+        let lr2 = scheduler.get_lr();
         scheduler.step(0.0);
-        let lr3 = scheduler.get_lr(0.0);
+        let lr3 = scheduler.get_lr();
 
         assert_relative_eq!(lr1, 0.1, epsilon = 1e-10, max_relative = 1e-10);
         assert!(lr2 > lr1); // Should increase during warmup
@@ -364,11 +364,11 @@ mod tests {
             OneCycleLR::new(1.0, 10, 0.0, AnnealStrategy::Linear, 10.0, 100.0, false);
 
         // With pct_start = 0.0, should start at max_lr
-        let lr_start = scheduler.get_lr(0.0);
+        let lr_start = scheduler.get_lr();
         assert_relative_eq!(lr_start, 1.0, epsilon = 1e-10, max_relative = 1e-10);
 
         scheduler.step(0.0);
-        let lr_next = scheduler.get_lr(0.0);
+        let lr_next = scheduler.get_lr();
         assert!(lr_next < lr_start); // Should immediately start decreasing
     }
 
@@ -383,7 +383,7 @@ mod tests {
         }
 
         // Should return min_lr
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.001, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -395,8 +395,8 @@ mod tests {
         // scheduler1: initial_lr = 1.0/5.0 = 0.2, min_lr = 0.2/50.0 = 0.004
         // scheduler2: initial_lr = 1.0/20.0 = 0.05, min_lr = 0.05/2000.0 = 0.000025
 
-        let lr1_start = scheduler1.get_lr(0.0);
-        let lr2_start = scheduler2.get_lr(0.0);
+        let lr1_start = scheduler1.get_lr();
+        let lr2_start = scheduler2.get_lr();
 
         assert_relative_eq!(lr1_start, 0.2, epsilon = 1e-10, max_relative = 1e-10);
         assert_relative_eq!(lr2_start, 0.05, epsilon = 1e-10, max_relative = 1e-10);

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::polynomial::PolynomialLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = PolynomialLR::new(1.0, 5, 1.0, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 8 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 0.8, 0.6, 0.4, 0.2, 0.0, 0.0, 0.0]);
@@ -26,10 +25,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// // Quadratic decay (power=2.0)
 /// let mut scheduler = PolynomialLR::new(1.0, 4, 2.0, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 6 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 0.5625, 0.25, 0.0625, 0.0, 0.0]);
@@ -42,10 +40,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 2;
 /// let mut scheduler = PolynomialLR::new(1.0, 5, 1.0, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 4 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [0.6, 0.4, 0.2, 0.0]);
@@ -57,12 +54,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::polynomial::PolynomialLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = PolynomialLR::new(1.0, 5, 1.0, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct PolynomialLR {
@@ -112,7 +108,7 @@ impl Scheduler for PolynomialLR {
         }
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -133,7 +129,7 @@ mod tests {
 
         let expected_lrs = [1.0, 0.8, 0.6, 0.4, 0.2, 0.0, 0.0, 0.0];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -149,7 +145,7 @@ mod tests {
 
         let expected_lrs = [1.0, 0.5625, 0.25, 0.0625, 0.0, 0.0];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -166,7 +162,7 @@ mod tests {
         // Expected values: 1.0, sqrt(0.75), sqrt(0.5), sqrt(0.25), 0.0
         let expected_lrs = [1.0, 0.75f64.sqrt(), 0.5f64.sqrt(), 0.5, 0.0];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -183,7 +179,7 @@ mod tests {
         // At init_step=2, factor = 1 - 2/5 = 0.6
         let expected_lrs = [0.6, 0.4, 0.2, 0.0];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -198,12 +194,12 @@ mod tests {
         let mut scheduler = PolynomialLR::new(base_lr, total_iters, power, init_step);
 
         // At init_step=5 (>= total_iters), lr should be 0
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
 
         // Should remain at 0
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -216,13 +212,13 @@ mod tests {
         let mut scheduler = PolynomialLR::new(base_lr, total_iters, power, init_step);
 
         // At init_step=10 (> total_iters), lr should be 0
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
 
         // Should remain at 0
         for _ in 0..5 {
             scheduler.step(0.0);
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
         }
     }
@@ -243,7 +239,7 @@ mod tests {
             0.0,
         ];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
@@ -258,12 +254,12 @@ mod tests {
         let mut scheduler = PolynomialLR::new(base_lr, total_iters, power, init_step);
 
         // At step 0, factor = 1 - 0/1 = 1.0, so lr = 1.0
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 1.0, epsilon = 1e-10, max_relative = 1e-10);
 
         // After one step, should be 0
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -276,11 +272,11 @@ mod tests {
         let mut scheduler = PolynomialLR::new(base_lr, total_iters, power, init_step);
 
         // With total_iters=0, lr should be 0 immediately
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
 
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -294,7 +290,7 @@ mod tests {
 
         let expected_lrs = [0.5, 0.375, 0.25, 0.125, 0.0];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }

--- a/src/reduce_lr_on_plateau.rs
+++ b/src/reduce_lr_on_plateau.rs
@@ -17,7 +17,7 @@
 //! scheduler.step(0.81); // loss=0.81, no improvement
 //! // lr is now reduced to 0.05
 //!
-//! assert_eq!(scheduler.get_lr(0.0), 0.05);
+//! assert_eq!(scheduler.get_lr(), 0.05);
 //! ```
 //!
 //! Different modes for different metrics:
@@ -31,7 +31,7 @@
 //! scheduler.step(0.8); // accuracy=0.8
 //! scheduler.step(0.85); // accuracy=0.85, improvement
 //! scheduler.step(0.84); // accuracy=0.84, no improvement (1/3)
-//! assert_eq!(scheduler.get_lr(0.0), 0.1); // lr not reduced yet
+//! assert_eq!(scheduler.get_lr(), 0.1); // lr not reduced yet
 //! ```
 //!
 //! Cooldown prevents immediate consecutive reductions:
@@ -187,7 +187,7 @@ impl Scheduler for ReduceLROnPlateau {
         }
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -214,22 +214,22 @@ mod tests {
 
         // Initial loss, establishes best
         scheduler.step(1.0);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
         assert_relative_eq!(scheduler.best, 1.0, epsilon = 1e-10);
 
         // Improvement
         scheduler.step(0.8);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
         assert_relative_eq!(scheduler.best, 0.8, epsilon = 1e-10);
 
         // No improvement (1/1)
         scheduler.step(0.85);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
         assert_eq!(scheduler.num_bad_epochs, 1);
 
         // No improvement, should trigger reduction
         scheduler.step(0.82);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
         assert_eq!(scheduler.num_bad_epochs, 0);
     }
 
@@ -249,11 +249,11 @@ mod tests {
 
         // Initial accuracy
         scheduler.step(0.8);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
 
         // Improvement
         scheduler.step(0.85);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
         assert_eq!(scheduler.num_bad_epochs, 0);
 
         // No improvement (1/2)
@@ -266,7 +266,7 @@ mod tests {
 
         // No improvement, should trigger reduction
         scheduler.step(0.82);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.01, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.01, epsilon = 1e-10);
     }
 
     #[test]
@@ -285,19 +285,19 @@ mod tests {
 
         scheduler.step(1.0);
         scheduler.step(1.1); // Triggers reduction
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // In cooldown, reduction is not triggered
         scheduler.step(1.2);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Still in cooldown
         scheduler.step(1.3);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Cooldown over, should trigger reduction
         scheduler.step(1.3);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.025, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.025, epsilon = 1e-10);
     }
 
     #[test]
@@ -316,11 +316,11 @@ mod tests {
 
         scheduler.step(1.0);
         scheduler.step(1.1); // Triggers reduction
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // With no cooldown, immediate reduction is possible
         scheduler.step(1.2);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.025, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.025, epsilon = 1e-10);
     }
 
     #[test]
@@ -339,19 +339,19 @@ mod tests {
 
         scheduler.step(1.0);
         scheduler.step(1.1); // Triggers reduction
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // In cooldown, reduction is not triggered
         scheduler.step(1.2);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Still in cooldown, but update best
         scheduler.step(0.1);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Cooldown over, should trigger reduction
         scheduler.step(0.5);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.025, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.025, epsilon = 1e-10);
     }
 
     #[test]
@@ -374,7 +374,7 @@ mod tests {
         // For relative threshold 0.01, improvement threshold = 1.0 * (1 - 0.01) = 0.99
         // 0.995 > 0.99, so this is NOT an improvement
         scheduler.step(0.995);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Reset for next test
         let mut scheduler = ReduceLROnPlateau::new(
@@ -392,7 +392,7 @@ mod tests {
 
         // 0.98 < 0.99, so this IS an improvement
         scheduler.step(0.98);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
     }
 
     #[test]
@@ -415,7 +415,7 @@ mod tests {
         // For absolute threshold 0.01, improvement threshold = 1.0 - 0.01 = 0.99
         // 0.995 > 0.99, so this is NOT an improvement
         scheduler.step(0.995);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Reset for next test
         let mut scheduler = ReduceLROnPlateau::new(
@@ -433,7 +433,7 @@ mod tests {
 
         // 0.98 < 0.99, so this IS an improvement
         scheduler.step(0.98);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
     }
 
     #[test]
@@ -454,15 +454,15 @@ mod tests {
 
         // First reduction: 0.1 * 0.5 = 0.05
         scheduler.step(1.1);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
 
         // Second reduction: 0.05 * 0.5 = 0.025, but min_lr = 0.03
         scheduler.step(1.2);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.03, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.03, epsilon = 1e-10);
 
         // Third reduction: should remain at min_lr
         scheduler.step(1.3);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.03, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.03, epsilon = 1e-10);
     }
 
     #[test]
@@ -485,7 +485,7 @@ mod tests {
         // Difference = 0.1 - 0.0999 = 0.0001 < eps = 0.001
         // So LR should not change
         scheduler.step(1.1);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
     }
 
     #[test]
@@ -512,13 +512,13 @@ mod tests {
         // Improvement resets counter
         scheduler.step(0.9);
         assert_eq!(scheduler.num_bad_epochs, 0);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
 
         // Now need 3 more bad epochs to trigger reduction
         scheduler.step(1.0);
         scheduler.step(1.1);
         scheduler.step(1.2);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
     }
 
     #[test]
@@ -537,11 +537,11 @@ mod tests {
 
         // First step establishes best = 1.0
         scheduler.step(1.0);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.1, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.1, epsilon = 1e-10);
 
         // With zero patience, any non-improvement should trigger reduction
         // 1.1 > 1.0, so bad_epochs = 1, and since patience = 0, we check > 0
         scheduler.step(1.1);
-        assert_relative_eq!(scheduler.get_lr(0.0), 0.05, epsilon = 1e-10);
+        assert_relative_eq!(scheduler.get_lr(), 0.05, epsilon = 1e-10);
     }
 }

--- a/src/step.rs
+++ b/src/step.rs
@@ -10,10 +10,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::step::StepLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = StepLR::new(1.0, 3, 0.1, 0);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 10 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.01, 0.01, 0.01, 0.001]);
@@ -26,10 +25,9 @@ use crate::Scheduler;
 /// # use lr_schedulers::Scheduler;
 /// let init_step = 2;
 /// let mut scheduler = StepLR::new(1.0, 3, 0.1, init_step);
-/// let mut learning_rates = Vec::new();
+/// let mut learning_rates: Vec<f64> = Vec::new();
 /// for _ in 0 .. 5 {
-///     // Note: loss value is not used in this scheduler.
-///     learning_rates.push(scheduler.get_lr(0.01));
+///     learning_rates.push(scheduler.get_lr());
 ///     scheduler.step(0.01);
 /// }
 /// assert_eq!(learning_rates, [1.0, 0.1, 0.1, 0.1, 0.01]);
@@ -41,12 +39,11 @@ use crate::Scheduler;
 /// # use lr_schedulers::step::StepLR;
 /// # use lr_schedulers::Scheduler;
 /// let mut scheduler = StepLR::new(1.0, 3, 0.1, 0);
-/// // Note: loss value is not used in this scheduler.
-/// let lr = scheduler.get_lr(0.01);
-/// assert_eq!(lr, scheduler.get_lr(0.01));
+/// let lr = scheduler.get_lr();
+/// assert_eq!(lr, scheduler.get_lr());
 /// scheduler.step(0.01);
-/// let lr = scheduler.get_lr(0.01);
-/// assert_ne!(lr, scheduler.get_lr(0.01));
+/// let new_lr = scheduler.get_lr();
+/// assert_ne!(lr, new_lr);
 /// ```
 #[derive(Debug, Clone)]
 pub struct StepLR {
@@ -83,7 +80,7 @@ impl Scheduler for StepLR {
         self.lr = self.base_lr * self.gamma.powi((self.step / self.step_size) as i32);
     }
 
-    fn get_lr(&self, _loss: f64) -> f64 {
+    fn get_lr(&self) -> f64 {
         self.lr
     }
 }
@@ -104,7 +101,7 @@ mod tests {
 
         let expected_lrs = [1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.01, 0.01, 0.01, 0.001];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -121,7 +118,7 @@ mod tests {
 
         let expected_lrs = [1.0, 0.1, 0.1, 0.1, 0.01];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -138,7 +135,7 @@ mod tests {
 
         let expected_lrs = [0.1, 0.1, 0.1, 0.01, 0.01];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -155,7 +152,7 @@ mod tests {
 
         let expected_lrs = [1.0, 0.5, 0.25, 0.125, 0.0625];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -172,13 +169,13 @@ mod tests {
 
         // Learning rate should remain constant for the first 100 steps
         for _ in 0..100 {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, base_lr, epsilon = 1e-10, max_relative = 1e-10);
             scheduler.step(0.0);
         }
 
         // After 100 steps, learning rate should be decayed
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, base_lr * gamma, epsilon = 1e-10, max_relative = 1e-10);
     }
 
@@ -192,7 +189,7 @@ mod tests {
 
         let expected_lrs = [0.1, 0.1, 0.2, 0.2, 0.4];
         for exp_lr in expected_lrs.iter() {
-            let lr = scheduler.get_lr(0.0);
+            let lr = scheduler.get_lr();
             assert_relative_eq!(lr, *exp_lr, epsilon = 1e-10, max_relative = 1e-10);
             // Proceed a step with dummy loss.
             scheduler.step(0.0);
@@ -209,12 +206,12 @@ mod tests {
 
         // At init_step=7, we should have decayed floor(7/2)=3 times
         // So lr = 1.0 * 0.1^3 = 0.001
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.001, epsilon = 1e-10, max_relative = 1e-10);
 
         // Step 8 (still in the same decay period)
         scheduler.step(0.0);
-        let lr = scheduler.get_lr(0.0);
+        let lr = scheduler.get_lr();
         assert_relative_eq!(lr, 0.0001, epsilon = 1e-10, max_relative = 1e-10);
     }
 }


### PR DESCRIPTION
## Summary

This PR removes the unused `loss` parameter from the `Scheduler` trait's `get_lr()` method to align with PyTorch's API design and improve code clarity.

## Problem

The current API requires users to pass a `loss` value to `get_lr()`, but:
- All 12 scheduler implementations ignore this parameter (using `_loss` prefix)
- Only `ReduceLROnPlateau` uses loss values, which it receives via `step()`, not `get_lr()`
- PyTorch's design has `get_lr()` take no parameters
- The API is misleading and inconsistent

## Solution

Remove the `loss` parameter from `get_lr()` to make it a simple getter that returns the current learning rate.

## Changes

- **Core API**: Updated `Scheduler` trait definition: `get_lr(&self, loss: f64)` → `get_lr(&self)`
- **Implementations**: Updated all 12 scheduler implementations to match new signature
- **Tests**: Updated ~186 test calls throughout the codebase
- **Documentation**: Updated README.md example and architecture documentation
- **Cleanup**: Removed obsolete "loss value is not used" comments

## Breaking Change

This is a **breaking change**. Users must update their code:

**Before:**
```rust
let lr = scheduler.get_lr(loss_value);
```

**After:**
```rust
let lr = scheduler.get_lr();
```

## Benefits

1. **Alignment with PyTorch**: Matches the widely-used PyTorch API design
2. **Clearer API**: No confusion about what the `loss` parameter does
3. **Better code**: Removes dead code and misleading signatures
4. **Easier to use**: Users don't need to pass dummy values
5. **Correct semantics**: `get_lr()` is a getter that returns current state

## Testing

- ✅ All 83 unit tests pass
- ✅ All 40 doc tests compile successfully
- ✅ Code formatted with `cargo fmt`
- ✅ Lint checks with `cargo clippy` pass (only pre-existing warnings)

## Version Impact

Should be released as version **0.3.0** (breaking change in 0.x.x series)

Close #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)